### PR TITLE
Add fix for building on x64 host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM i386/debian:buster
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 A turnkey GNU/Linux solution that transforms a Raspberry Pi to an Android Auto head unit.
 
 https://getcrankshaft.com/
+
+# Docker build image
+
+- Create config for pi-gen
+```bash
+cp config.example config
+```
+- Build image
+```bash
+./build-docker.sh
+```

--- a/config.example
+++ b/config.example
@@ -1,0 +1,11 @@
+IMG_NAME='crankshaft-ng'
+ENABLE_SSH=0
+STAGE_LIST='stage0 stage1 stage2 stage3'
+#these are the defaults uncomment to change
+#FIRST_USER_NAME=pi
+#FIRST_USER_PASS=raspberry
+# Uncomment this if a build fails and you'd like to try again
+#CONTINUE=1
+IMG_VERSION=v1-${IMG_NAME}
+IMG_FILENAME=${IMG_VERSION}
+ZIP_FILENAME=${IMG_VERSION}


### PR DESCRIPTION
when building on an x64 host curl fails due to [pi-gen Qemu x64 issue](https://github.com/RPi-Distro/pi-gen/issues/271#issuecomment-556812205)